### PR TITLE
Feat: add contacts as api endpoint

### DIFF
--- a/src/billomat-resource-client.ts
+++ b/src/billomat-resource-client.ts
@@ -158,6 +158,7 @@ const SINGULAR = new Map<Billomat.ResourceName, string>([
     ['client-property-values', 'client-property-value'],
     ['confirmations', 'confirmation'],
     ['countries', 'country'],
+    ['contacts', 'contact'],
     ['credit-notes', 'credit-note'],
     ['currencies', 'currency'],
     ['delivery-notes', 'delivery-note'],

--- a/src/billomat.api.spec.ts
+++ b/src/billomat.api.spec.ts
@@ -30,7 +30,7 @@ const SINGULAR_OF_RESOURCE = {
 };
 
 const isImplemented = (resourceName: ResourceName): boolean =>
-    ['clients', 'client-property-values', 'confirmations', 'invoices'].includes(resourceName);
+    ['clients', 'client-property-values', 'confirmations', 'contacts', 'invoices'].includes(resourceName);
 
 describe('Billomat API', () => {
     const api = getBillomatApiClient({ baseUrl: 'billomat.net', apiKey: 'a valid key' });

--- a/src/billomat.api.spec.ts
+++ b/src/billomat.api.spec.ts
@@ -14,6 +14,7 @@ const SINGULAR_OF_RESOURCE = {
     clients: 'client',
     confirmations: 'confirmation',
     countries: 'country',
+    contacts: 'contact',
     'credit-notes': 'credit-note',
     currencies: 'currency',
     'delivery-notes': 'delivery-note',

--- a/src/billomat.ts
+++ b/src/billomat.ts
@@ -121,6 +121,30 @@ export namespace Billomat {
         customfield?: string;
     }
 
+    export interface Contact extends Resource {
+        created?: string;
+        updated?: string;
+        client_id: string;
+        label?: string;
+        name?: string;
+        salutation?: string;
+        first_name?: string;
+        last_name?: string;
+        street?: string;
+        zip?: string;
+        city?: string;
+        state?: string;
+        country_code?: string;
+        address?: string;
+        phone?: string;
+        fax?: string;
+        mobile?: string;
+        email?: string;
+        www?: string;
+        locale?: string;
+        customfield?: string;
+    }
+
     export interface Invoice extends Resource {
         created?: string;
         updated?: string;

--- a/src/get-billomat-api-client.ts
+++ b/src/get-billomat-api-client.ts
@@ -8,6 +8,7 @@ export const BILLOMAT_RESOURCE_NAMES = [
     'clients',
     'confirmations',
     'countries',
+    'contacts',
     'credit-notes',
     'currencies',
     'delivery-notes',
@@ -27,6 +28,7 @@ export interface MappedBillomatResourceType {
     'client-property-values': Billomat.ClientPropertyValue;
     clients: Billomat.Client;
     confirmations: Billomat.Confirmation;
+    contacts: Billomat.Contact;
     invoices: Billomat.Invoice;
 
     [name: string]: Billomat.Resource;

--- a/src/test-data/contacts-create-response.json
+++ b/src/test-data/contacts-create-response.json
@@ -1,0 +1,26 @@
+{
+    "contact": {
+        "id": "12345",
+        "created": "2021-04-24T18:12:28+02:00",
+        "updated": "2021-04-24T23:43:37+02:00",
+        "client_id": "1111111",
+        "label": "Kontakt-01",
+        "name": "A dummy contact",
+        "salutation": "",
+        "first_name": "John",
+        "last_name": "Doe",
+        "street": "Musterstraße 1",
+        "zip": "",
+        "city": "Musterhausen",
+        "state": "",
+        "country_code": "DE",
+        "address": "Musterfirma\nMax Muster\nMusterstraße 1\nMusterhausen",
+        "phone": "",
+        "fax": "",
+        "mobile": "",
+        "email": "",
+        "www": "",
+        "locale": "",
+        "customfield": ""
+    }
+}

--- a/src/test-data/contacts-get-response.json
+++ b/src/test-data/contacts-get-response.json
@@ -1,0 +1,26 @@
+{
+    "contact": {
+        "id": "12345",
+        "created": "2021-04-24T18:12:28+02:00",
+        "updated": "2021-04-24T23:43:37+02:00",
+        "client_id": "1111111",
+        "label": "Kontakt-01",
+        "name": "A dummy contact",
+        "salutation": "",
+        "first_name": "John",
+        "last_name": "Doe",
+        "street": "Musterstraße 1",
+        "zip": "",
+        "city": "Musterhausen",
+        "state": "",
+        "country_code": "DE",
+        "address": "Musterfirma\nMax Muster\nMusterstraße 1\nMusterhausen",
+        "phone": "",
+        "fax": "",
+        "mobile": "",
+        "email": "",
+        "www": "",
+        "locale": "",
+        "customfield": ""
+    }
+}

--- a/src/test-data/contacts-list-response.json
+++ b/src/test-data/contacts-list-response.json
@@ -1,0 +1,33 @@
+{
+    "contacts": {
+        "contact": [
+            {
+                "id": "12345",
+                "created": "2021-04-24T18:12:28+02:00",
+                "updated": "2021-04-24T23:43:37+02:00",
+                "client_id": "1111111",
+                "label": "Kontakt-01",
+                "name": "A dummy contact",
+                "salutation": "",
+                "first_name": "John",
+                "last_name": "Doe",
+                "street": "Musterstraße 1",
+                "zip": "",
+                "city": "Musterhausen",
+                "state": "",
+                "country_code": "DE",
+                "address": "Musterfirma\nMax Muster\nMusterstraße 1\nMusterhausen",
+                "phone": "",
+                "fax": "",
+                "mobile": "",
+                "email": "",
+                "www": "",
+                "locale": "",
+                "customfield": ""
+            }
+        ],
+        "@page": "1",
+        "@per_page": "100",
+        "@total": "1"
+    }
+}


### PR DESCRIPTION
The Billomat-API also supports accessing and editing the contacts of a customer. This pull requests adds the necessary resource.

Example usage:
```ts
const clientId = '12345'; // any existing client id
let contacts = await this.apiClient.contacts.list({ client_id: clientId });
```

Details about the endpoints can be found in the official documentation: https://www.billomat.com/api/kunden/kontakte/